### PR TITLE
Fix test assumptions

### DIFF
--- a/src/forms/Y2020/tests/f1040.test.ts
+++ b/src/forms/Y2020/tests/f1040.test.ts
@@ -17,11 +17,26 @@ describe('f1040', () => {
     await testKit.with1040Assert(async (forms) => {
       const f1040 = commonTests.findF1040OrFail(forms)
       expect(f1040).not.toBeUndefined()
-      // tax is less than taxable income
-      if (f1040?.l15() ?? 0 > 0) {
-        expect(f1040?.l24() ?? 0).toBeLessThan(f1040?.l15() ?? 0)
+      // tax is less than AGI
+      if (f1040?.l11() ?? 0 > 0) {
+        expect(f1040?.l24() ?? 0).toBeLessThanOrEqual(f1040?.l11() ?? 0)
       } else {
         expect(f1040?.l24() ?? 0).toEqual(0)
+      }
+    })
+  })
+
+  it('should never produce tax on taxable income higher than income', async () => {
+    await testKit.with1040Assert(async (forms) => {
+      const f1040 = commonTests.findF1040(forms)
+      expect(f1040).not.toBeUndefined()
+      if (f1040 !== undefined) {
+        // tax on taxable income should be less than taxable income
+        if (f1040.l15() ?? 0 > 0) {
+          expect(f1040.l16() ?? 0).toBeLessThan(f1040.l15() ?? 0)
+        } else {
+          expect(f1040.l16() ?? 0).toEqual(0)
+        }
       }
     })
   })

--- a/src/forms/Y2021/tests/f1040.test.ts
+++ b/src/forms/Y2021/tests/f1040.test.ts
@@ -13,16 +13,31 @@ beforeAll(() => {
 describe('f1040', () => {
   commonTests.run()
 
-  it('should never produce higher tax than income', async () => {
+  it('should never produce higher tax than AGI', async () => {
     await testKit.with1040Assert(async (forms) => {
       const f1040 = commonTests.findF1040(forms)
       expect(f1040).not.toBeUndefined()
       if (f1040 !== undefined) {
-        // tax is less than taxable income
-        if (f1040.l15() ?? 0 > 0) {
-          expect(f1040.l24() ?? 0).toBeLessThan(f1040.l15() ?? 0)
+        // tax is less than AGI
+        if (f1040.l11() ?? 0 > 0) {
+          expect(f1040.l24() ?? 0).toBeLessThanOrEqual(f1040.l11() ?? 0)
         } else {
           expect(f1040.l24() ?? 0).toEqual(0)
+        }
+      }
+    })
+  })
+
+  it('should never produce tax on taxable income higher than income', async () => {
+    await testKit.with1040Assert(async (forms) => {
+      const f1040 = commonTests.findF1040(forms)
+      expect(f1040).not.toBeUndefined()
+      if (f1040 !== undefined) {
+        // tax on taxable income should be less than taxable income
+        if (f1040.l15() ?? 0 > 0) {
+          expect(f1040.l16() ?? 0).toBeLessThan(f1040.l15() ?? 0)
+        } else {
+          expect(f1040.l16() ?? 0).toEqual(0)
         }
       }
     })


### PR DESCRIPTION
Due to adding HSA distributions, we can no longer assume that
total tax is less than taxable income. But we can still assume that
the tax on taxable income (L16 tax on L15 income) is less than taxable
income. And we can also assume that total tax must be less than AGI.

**What kind of change does this PR introduce?** 
- Bugfix

